### PR TITLE
Add GitHub Django CI workflow

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,0 +1,34 @@
+name: Django CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          
+      - name: Django check
+        run: |
+          python manage.py check
+          
+      - name: Run Tests
+        run: |
+          python manage.py test
+        


### PR DESCRIPTION
Adds GitHub Actions CI to run `python manage.py check` and `python manage.py test ` on PRs to main. Satisfy spec requirement for unit tests.